### PR TITLE
Fix the remaining warnings and small type fix in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ are still under construction, such as the LL1HeapColourParser.
 The ParParser, an experimental parallel parser, has poor
 performance.
 
-Also RcTransl, an tool for language translation between
-Windows resource files, is still under development. 
+Also RcTransl, a tool for language translation between
+Windows resource files, is still under development.
 
 http://www.iwriteiam.nl/MM.html
 

--- a/software/LL1HeapColourParser.cpp
+++ b/software/LL1HeapColourParser.cpp
@@ -86,7 +86,7 @@ class LL1HeapColourParseProcess
 {
 	friend class LL1HeapColourParser;
 public:
-	LL1HeapColourParseProcess(LL1HeapColourParser* parser) : _parser(parser), _state(0), _parent_process(0) {}
+	LL1HeapColourParseProcess(LL1HeapColourParser* parser) : _state(0), _parser(parser), _parent_process(0) {}
 	virtual ~LL1HeapColourParseProcess() {}
 	virtual void execute() = 0;
 protected:

--- a/software/TextReader.cpp
+++ b/software/TextReader.cpp
@@ -2,7 +2,7 @@
 #ifdef WIN32
 #include <io.h>
 #else
-#include <sys/io.h>
+#include <unistd.h>
 #endif
 
 #include "TextReader.h"


### PR DESCRIPTION
Thank you for the latest fixes !
When compiling on Ubuntu 18.04 and usgin g++-9 there was still two small problems.

Also on the README you say:
```
The diff should not find any differences.
```
But I get this output (the diff really show no differences):
```
Iparse, Version: 1.7 of February 17, 2021.
Processing: software/c.gr
Processing: others/scan.pc
Processing: -p
tree:

--------------
Iparse, Version: 1.7 of February 17, 2021.
Processing: software/c.gr
Processing: others/scan.pc
Processing: -unparse
Error: different rules with type ident
	213.21 [213.21]<ident> 
	2.11 [2.11]<ident> 
```
